### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ async function start() {
     let table_observer = new PgTableObserver(db, 'myapp');
 
     async function cleanupAndExit() {
-      await table_observer.cleanup();
-      pgp.end();
+      await table_observer.cleanup();      
       process.exit();
     }
 


### PR DESCRIPTION
There is no point shutting down all connection pools, if the next thing you do is exit the process.

And if you do want to shut down that which you're using, then with pg-promise 6.x you shut down only the pool you are using: `db.$pool.end()`